### PR TITLE
Remove actuality label from mobile data

### DIFF
--- a/data/BYTE-635_attachments/echarts_030724/echarts_mobile.js
+++ b/data/BYTE-635_attachments/echarts_030724/echarts_mobile.js
@@ -70,7 +70,7 @@ const gaugeData = [
     title: [{
       text: 'Mobilfunknetzabdeckung'},
       {
-        subtext: 'CC BY – MIG, BMDV. Datenstand 01.07.2022',
+        subtext: 'CC BY – MIG, BMDV',
         top: 15,
         subtextStyle:{color: '#687178', fontSize: 12}
       },


### PR DESCRIPTION
The label may not represent the actual data actuality given from the data source. Instead, the label may be omitted.